### PR TITLE
Show only future meetups with javascript filtering

### DIFF
--- a/source/_snippets/meetups/table.twig
+++ b/source/_snippets/meetups/table.twig
@@ -27,7 +27,7 @@
     {% for meetup in meetups %}
         {% set days_from_today = diff_from_today_in_days(meetup.start) %}
         {% if days_from_today <= max_forecast_days %}
-            <tr class="meetup" data-longitude="{{ meetup.longitude }}" data-latitude="{{ meetup.latitude}}">
+            <tr class="meetup" data-longitude="{{ meetup.longitude }}" data-latitude="{{ meetup.latitude}}" data-datetime="{{ meetup.start|date("Y-m-d H:i") }}">
                 <td class="w-25">
                     <nobr>{{ meetup.start|date("D, M d") }}</nobr>
                     <br>

--- a/source/_snippets/meetups_map_js.twig
+++ b/source/_snippets/meetups_map_js.twig
@@ -22,7 +22,9 @@
                         "position": [{{ meetup.latitude }}, {{ meetup.longitude }}],
                         "date": "{{ meetup.start|date("m-d") }}",
                         "location": "{{ meetup.city }}",
-                        "url": "{{ meetup.url }}"
+                        "url": "{{ meetup.url }}",
+                        // for filtering
+                        "datetime": "{{ meetup.start|date("Y-m-d H:i") }}",
                     },
                 {% endif %}
             {% endfor %}
@@ -33,8 +35,17 @@
 
     var grouped = {};
 
+    var now = new Date();
+    var nowDateTime = Date.parse(now);
+
     for (var i in markers) {
         var marker = markers[i];
+
+        // is in the past?
+        var meetupDateTime = Date.parse(marker.datetime);
+        if (meetupDateTime < nowDateTime) {
+            continue;
+        }
 
         // group meetups in one location
         if (typeof grouped[marker.location] == 'undefined') {

--- a/source/assets/js/menu-area-pick.js
+++ b/source/assets/js/menu-area-pick.js
@@ -2,10 +2,20 @@
 
 $(function() {
     var showRowsInBounds = function(bounds) {
+        var now = new Date();
+
         $("tr.meetup").each(function () {
             var meetupLatLng = L.latLng($(this).data('latitude'), $(this).data('longitude'));
             if (bounds.contains(meetupLatLng)) {
-                $(this).show();
+                // is in the past?
+                var meetupDateTime = Date.parse($(this).data('datetime'));
+                var nowDateTime = Date.parse(now);
+
+                if (meetupDateTime < nowDateTime) {
+                    $(this).hide();
+                } else {
+                    $(this).show();
+                }
             } else {
                 $(this).hide();
             }


### PR DESCRIPTION
On 2018-02-21 morning, there were also incorrectly displayed meetup from yesterday. 

## Before :cry: 

![before](https://user-images.githubusercontent.com/924196/53168463-f4efa700-35da-11e9-9ff0-a2d677bb9f9b.png)

---

## After  :smiley: 

![after](https://user-images.githubusercontent.com/924196/53168462-f4efa700-35da-11e9-80ed-aba7b5ce4da0.png)
